### PR TITLE
feat: broaden app subtitle

### DIFF
--- a/src/components/Sidebar/AppSidebar.tsx
+++ b/src/components/Sidebar/AppSidebar.tsx
@@ -123,7 +123,7 @@ export const AppSidebar = (props: React.ComponentProps<typeof Sidebar>) => {
               {t('appName', { defaultValue: 'Funges' })}
             </h2>
             <p className='text-xs text-muted-foreground'>
-              {t('appDescription', { defaultValue: 'Mushroom Guide' })}
+              {t('appDescription', { defaultValue: 'Foraging Guide' })}
             </p>
           </div>
         </div>

--- a/src/i18n/locales/de/common.json
+++ b/src/i18n/locales/de/common.json
@@ -1,7 +1,7 @@
 {
   "common": {
     "appName": "Funges",
-    "appDescription": "Pilzführer",
+    "appDescription": "Sammel-Guide",
     "loading": "Lädt...",
     "error": "Ein Fehler ist aufgetreten",
     "success": "Erfolg",

--- a/src/i18n/locales/de/sidebar.json
+++ b/src/i18n/locales/de/sidebar.json
@@ -1,6 +1,6 @@
 {
   "appName": "Funges",
-  "appDescription": "Pilz-Sammel-App",
+  "appDescription": "Sammel-Guide",
   "map": "Karte",
   "species": "Arten",
   "recipes": "Rezepte",

--- a/src/i18n/locales/en/common.json
+++ b/src/i18n/locales/en/common.json
@@ -1,7 +1,7 @@
 {
   "common": {
     "appName": "Funges",
-    "appDescription": "Mushroom Guide",
+    "appDescription": "Foraging Guide",
     "loading": "Loading...",
     "error": "An error occurred",
     "success": "Success",

--- a/src/i18n/locales/en/sidebar.json
+++ b/src/i18n/locales/en/sidebar.json
@@ -1,6 +1,6 @@
 {
   "appName": "Funges",
-  "appDescription": "Mushroom Guide",
+  "appDescription": "Foraging Guide",
   "map": "Map",
   "species": "Species",
   "recipes": "Recipes",

--- a/src/i18n/locales/es/common.json
+++ b/src/i18n/locales/es/common.json
@@ -1,7 +1,7 @@
 {
   "common": {
     "appName": "Funges",
-    "appDescription": "Guía de hongos",
+    "appDescription": "Guía de recolección",
     "loading": "Cargando...",
     "error": "Ocurrió un error",
     "success": "Éxito",

--- a/src/i18n/locales/es/sidebar.json
+++ b/src/i18n/locales/es/sidebar.json
@@ -1,6 +1,6 @@
 {
   "appName": "Funges",
-  "appDescription": "Guía de hongos",
+  "appDescription": "Guía de recolección",
   "map": "Mapa",
   "species": "Especies",
   "recipes": "Recetas",

--- a/src/i18n/locales/fr/common.json
+++ b/src/i18n/locales/fr/common.json
@@ -1,7 +1,7 @@
 {
   "common": {
     "appName": "Funges",
-    "appDescription": "Guide des champignons",
+    "appDescription": "Guide de cueillette",
     "loading": "Chargement...",
     "error": "Une erreur est survenue",
     "success": "Succès",

--- a/src/i18n/locales/fr/sidebar.json
+++ b/src/i18n/locales/fr/sidebar.json
@@ -1,6 +1,6 @@
 {
   "appName": "Funges",
-  "appDescription": "Guide des champignons",
+  "appDescription": "Guide de cueillette",
   "map": "Carte",
   "species": "Espèces",
   "recipes": "Recettes",

--- a/src/i18n/locales/it/common.json
+++ b/src/i18n/locales/it/common.json
@@ -21,7 +21,7 @@
   },
   "common": {
     "appName": "Funges",
-    "appDescription": "Guida ai Funghi",
+    "appDescription": "Guida alla raccolta",
     "loading": "Caricamento...",
     "error": "Si è verificato un errore",
     "retry": "Riprova",

--- a/src/i18n/locales/it/sidebar.json
+++ b/src/i18n/locales/it/sidebar.json
@@ -1,6 +1,6 @@
 {
   "appName": "Funges",
-  "appDescription": "Guida ai funghi",
+  "appDescription": "Guida alla raccolta",
   "map": "Mappa",
   "species": "Specie",
   "recipes": "Ricette",

--- a/src/i18n/locales/pt/common.json
+++ b/src/i18n/locales/pt/common.json
@@ -1,7 +1,7 @@
 {
   "common": {
     "appName": "Funges",
-    "appDescription": "Guia de Cogumelos",
+    "appDescription": "Guia de forrageamento",
     "loading": "Carregando...",
     "error": "Ocorreu um erro",
     "success": "Sucesso",

--- a/src/i18n/locales/pt/sidebar.json
+++ b/src/i18n/locales/pt/sidebar.json
@@ -1,6 +1,6 @@
 {
   "appName": "Funges",
-  "appDescription": "Guia de cogumelos",
+  "appDescription": "Guia de forrageamento",
   "map": "Mapa",
   "species": "Espécies",
   "recipes": "Receitas",


### PR DESCRIPTION
## Summary
- change app subtitle from "Mushroom Guide" to "Foraging Guide" across components and locale files

## Testing
- `npm run lint`
- `npm run test` *(fails: Playwright and markdown-to-jsx unavailable)*

------
https://chatgpt.com/codex/tasks/task_e_68a6128cdb188331a43db20833888184