### PR TITLE
feat: add map data freshness indicator

### DIFF
--- a/src/components/AdvancedMap.tsx
+++ b/src/components/AdvancedMap.tsx
@@ -11,6 +11,7 @@ import FeatureInfoModal from './FeatureInfoModal';
 import MapErrorBoundary from './MapErrorBoundary';
 import MapFallback from './MapFallback';
 import LoadingSquirrel from '@/assets/images/loading_squirrel.gif';
+import LastUpdatedIndicator from './LastUpdatedIndicator';
 
 import { motion } from 'framer-motion';
 
@@ -528,6 +529,8 @@ const AdvancedMap: React.FC<MapProps> = ({ className = '' }) => {
             </Card>
           </div>
         )}
+
+        <LastUpdatedIndicator />
       </div>
       <FeatureInfoModal
         feature={selectedFeature}

--- a/src/components/LastUpdatedIndicator.tsx
+++ b/src/components/LastUpdatedIndicator.tsx
@@ -1,0 +1,65 @@
+import React, { useMemo } from 'react';
+import { useTranslation } from 'react-i18next';
+import {
+  Tooltip,
+  TooltipTrigger,
+  TooltipContent,
+} from '@/components/ui/tooltip';
+import { useMapStore } from '@/store/mapStore';
+
+const formatLastUpdated = (timestamp: string, locale: string): string => {
+  const date = new Date(timestamp);
+  const now = new Date();
+  const diff = now.getTime() - date.getTime();
+  const msInMinute = 60 * 1000;
+  const msInHour = 60 * msInMinute;
+  const msInDay = 24 * msInHour;
+
+  if (diff < msInDay) {
+    const rtf = new Intl.RelativeTimeFormat(locale, { numeric: 'auto' });
+    if (diff < msInHour) {
+      const minutes = Math.round(diff / msInMinute);
+      return rtf.format(-minutes, 'minute');
+    }
+    const hours = Math.round(diff / msInHour);
+    return rtf.format(-hours, 'hour');
+  }
+
+  return new Intl.DateTimeFormat(locale, {
+    weekday: 'short',
+    month: 'short',
+    day: 'numeric',
+    year: 'numeric',
+    hour: 'numeric',
+    minute: '2-digit',
+  }).format(date);
+};
+
+const LastUpdatedIndicator: React.FC = () => {
+  const { t, i18n } = useTranslation('map');
+  const lastDataRefresh = useMapStore(state => state.lastDataRefresh);
+
+  const formatted = useMemo(() => {
+    if (!lastDataRefresh) return null;
+    return formatLastUpdated(lastDataRefresh, i18n.language);
+  }, [lastDataRefresh, i18n.language]);
+
+  if (!formatted) return null;
+
+  return (
+    <div className='absolute bottom-4 right-4 z-20'>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <div className='rounded-md bg-black/70 px-2 py-1 text-xs text-white'>
+            {t('lastUpdated')}: {formatted}
+          </div>
+        </TooltipTrigger>
+        <TooltipContent side='top'>
+          <p>{t('lastUpdatedInfo')}</p>
+        </TooltipContent>
+      </Tooltip>
+    </div>
+  );
+};
+
+export default LastUpdatedIndicator;

--- a/src/i18n/locales/de/map.json
+++ b/src/i18n/locales/de/map.json
@@ -63,5 +63,7 @@
     "title": "Feature-Details",
     "getDirections": "Route abrufen",
     "location": "Standort"
-  }
+  },
+  "lastUpdated": "Zuletzt aktualisiert",
+  "lastUpdatedInfo": "Kartendaten werden aktualisiert, wenn neue Daten geladen werden."
 }

--- a/src/i18n/locales/en/map.json
+++ b/src/i18n/locales/en/map.json
@@ -62,5 +62,7 @@
     "title": "Feature Details",
     "getDirections": "Get Directions",
     "location": "Location"
-  }
+  },
+  "lastUpdated": "Last updated",
+  "lastUpdatedInfo": "Map data refreshes when new data is loaded."
 }

--- a/src/i18n/locales/es/map.json
+++ b/src/i18n/locales/es/map.json
@@ -63,5 +63,7 @@
     "title": "Detalles de la función",
     "getDirections": "Obtener indicaciones",
     "location": "Ubicación"
-  }
+  },
+  "lastUpdated": "Última actualización",
+  "lastUpdatedInfo": "Los datos del mapa se actualizan cuando se cargan nuevos datos."
 }

--- a/src/i18n/locales/fr/map.json
+++ b/src/i18n/locales/fr/map.json
@@ -63,5 +63,7 @@
     "title": "Détails de la fonctionnalité",
     "getDirections": "Obtenir l'itinéraire",
     "location": "Emplacement"
-  }
+  },
+  "lastUpdated": "Dernière mise à jour",
+  "lastUpdatedInfo": "Les données de la carte se mettent à jour lorsque de nouvelles données sont chargées."
 }

--- a/src/i18n/locales/it/map.json
+++ b/src/i18n/locales/it/map.json
@@ -62,5 +62,7 @@
     "title": "Dettagli Feature",
     "getDirections": "Ottieni Indicazioni",
     "location": "Località"
-  }
+  },
+  "lastUpdated": "Ultimo aggiornamento",
+  "lastUpdatedInfo": "I dati della mappa si aggiornano quando vengono caricati nuovi dati."
 }

--- a/src/i18n/locales/pt/map.json
+++ b/src/i18n/locales/pt/map.json
@@ -63,5 +63,7 @@
     "title": "Detalhes da funcionalidade",
     "getDirections": "Obter direções",
     "location": "Localização"
-  }
+  },
+  "lastUpdated": "Última atualização",
+  "lastUpdatedInfo": "Os dados do mapa são atualizados quando novos dados são carregados."
 }

--- a/src/store/mapStore.ts
+++ b/src/store/mapStore.ts
@@ -54,6 +54,9 @@ export interface MapState {
   // Map reference for layer management
   mapRef: mapboxgl.Map | null;
 
+  // Data freshness
+  lastDataRefresh: string | null;
+
   // Actions
   setCenter: (center: [number, number]) => void;
   setZoom: (zoom: number) => void;
@@ -83,6 +86,8 @@ export interface MapState {
   setMapRef: (map: mapboxgl.Map | null) => void;
   updateVisibleLayers: () => void;
   restoreDarkLayersState: () => void;
+
+  setLastDataRefresh: (timestamp: string) => void;
 }
 
 export const useMapStore = create<MapState>()(
@@ -111,6 +116,8 @@ export const useMapStore = create<MapState>()(
       showUserLocation: true,
       mapRef: null,
 
+      lastDataRefresh: null,
+
       // Actions
       setCenter: center => set({ center }),
       setZoom: zoom => set({ zoom }),
@@ -119,7 +126,8 @@ export const useMapStore = create<MapState>()(
       setMapStyle: mapStyle => set({ mapStyle }),
       setUserLocation: userLocation => set({ userLocation }),
       setUserLocationError: userLocationError => set({ userLocationError }),
-      setForagingSpots: foragingSpots => set({ foragingSpots }),
+      setForagingSpots: foragingSpots =>
+        set({ foragingSpots, lastDataRefresh: new Date().toISOString() }),
       setSelectedSpot: selectedSpot => set({ selectedSpot }),
       setIsLoading: isLoading => set({ isLoading }),
       setError: error => set({ error }),
@@ -256,7 +264,11 @@ export const useMapStore = create<MapState>()(
             lastUpdated: new Date().toISOString(),
           }));
 
-          set({ foragingSpots: spots, isLoading: false });
+          set({
+            foragingSpots: spots,
+            isLoading: false,
+            lastDataRefresh: new Date().toISOString(),
+          });
         } catch (error) {
           // Don't set an error for this background operation, just log it
           console.warn('Failed to fetch nearby foraging spots:', error);
@@ -268,6 +280,7 @@ export const useMapStore = create<MapState>()(
       addForagingSpot: spot =>
         set(state => ({
           foragingSpots: [...state.foragingSpots, spot],
+          lastDataRefresh: new Date().toISOString(),
         })),
 
       updateForagingSpot: (id, updates) =>
@@ -275,15 +288,18 @@ export const useMapStore = create<MapState>()(
           foragingSpots: state.foragingSpots.map(spot =>
             spot.id === id ? { ...spot, ...updates } : spot
           ),
+          lastDataRefresh: new Date().toISOString(),
         })),
 
       removeForagingSpot: id =>
         set(state => ({
           foragingSpots: state.foragingSpots.filter(spot => spot.id !== id),
+          lastDataRefresh: new Date().toISOString(),
         })),
 
       // Map reference management
       setMapRef: (map: mapboxgl.Map | null) => set({ mapRef: map }),
+      setLastDataRefresh: lastDataRefresh => set({ lastDataRefresh }),
       updateVisibleLayers: () => {
         const {
           mapRef,


### PR DESCRIPTION
## Summary
- show map data freshness chip with relative/absolute timestamp
- track refresh time in map store and update on data changes
- localize indicator text

## Testing
- `npm run lint`
- `npm run test` *(fails: browserType.launch: Executable doesn't exist at /root/.cache/ms-playwright/chromium_headless_shell-1181/chrome-linux/headless_shell)*

------
https://chatgpt.com/codex/tasks/task_e_68a612e78e4c83318157bee2ba75cab9