### PR TITLE
Add onboarding info button

### DIFF
--- a/src/components/AdvancedMap.tsx
+++ b/src/components/AdvancedMap.tsx
@@ -3,8 +3,9 @@ import mapboxgl from 'mapbox-gl';
 import 'mapbox-gl/dist/mapbox-gl.css';
 import { useMapStore } from '@/store/mapStore';
 import { Card } from '@/components/ui/card';
-import { Loader2, MapPin, Navigation, Moon, Hash } from 'lucide-react';
+import { Loader2, MapPin, Navigation, Moon, Hash, Info } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
+import { useUIStore } from '@/store/uiStore';
 import SpeciesSelector from './SpeciesSelector';
 import { useIsMobile } from '@/hooks/use-mobile';
 import FeatureInfoModal from './FeatureInfoModal';
@@ -31,6 +32,7 @@ const AdvancedMap: React.FC<MapProps> = ({ className = '' }) => {
   const isMobile = useIsMobile();
 
   const { t } = useTranslation('map');
+  const { setActiveModal } = useUIStore();
   const {
     center,
     zoom,
@@ -467,6 +469,23 @@ const AdvancedMap: React.FC<MapProps> = ({ className = '' }) => {
             }}
           >
             <Moon className='h-4 w-4' />
+          </motion.button>
+
+          {/* Info button */}
+          <motion.button
+            onClick={() => setActiveModal('onboarding')}
+            className='inline-flex items-center justify-center rounded-md text-sm font-medium ring-offset-background transition-colors disabled:pointer-events-none disabled:opacity-50 border h-9 px-3 shadow-lg bg-secondary border-input'
+            title={t('showOnboarding')}
+            whileHover={{ scale: 1.02 }}
+            whileTap={{ scale: 0.95 }}
+            transition={{
+              duration: 0.2,
+              type: 'spring',
+              stiffness: 400,
+              damping: 25,
+            }}
+          >
+            <Info className='h-4 w-4' />
           </motion.button>
         </div>
 

--- a/src/components/OnboardingModal.tsx
+++ b/src/components/OnboardingModal.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from 'react';
 import { Link } from '@tanstack/react-router';
 import { useTranslation } from 'react-i18next';
 import { List, Navigation, Hash, Moon, MousePointerClick } from 'lucide-react';
+import { useUIStore } from '@/store/uiStore';
 
 import {
   Dialog,
@@ -17,6 +18,7 @@ const ONBOARDING_KEY = 'onboardingDismissed';
 
 export default function OnboardingModal() {
   const { t } = useTranslation('map');
+  const { activeModal, setActiveModal } = useUIStore();
   const [open, setOpen] = useState(false);
 
   useEffect(() => {
@@ -25,10 +27,17 @@ export default function OnboardingModal() {
     }
   }, []);
 
+  useEffect(() => {
+    if (activeModal === 'onboarding') {
+      setOpen(true);
+    }
+  }, [activeModal]);
+
   function handleOpenChange(value: boolean) {
     setOpen(value);
     if (!value) {
       localStorage.setItem(ONBOARDING_KEY, 'true');
+      setActiveModal(null);
     }
   }
 

--- a/src/i18n/locales/de/map.json
+++ b/src/i18n/locales/de/map.json
@@ -59,7 +59,7 @@
   "getLocation": "Meinen Standort ermitteln",
   "toggleNumbers": "Zahlen ein-/ausblenden",
   "toggleDarkMode": "Dunkelmodus umschalten",
-  "showOnboarding": "Show onboarding",
+  "showOnboarding": "Anleitung anzeigen",
   "dataFreshnessTooltip": "Daten werden täglich aktualisiert",
   "featureInfo": {
     "title": "Feature-Details",
@@ -67,16 +67,16 @@
     "location": "Standort"
   },
   "onboarding": {
-    "title": "Explore wild species",
-    "description": "Use the map to discover foraging spots and species.",
+    "title": "Wilde Arten erkunden",
+    "description": "Nutze die Karte, um Sammelorte und Arten zu entdecken.",
     "features": {
-      "species": "Choose a species with the selector",
-      "locate": "Center the map on your location",
-      "numbers": "Show or hide the numeric index",
-      "theme": "Switch between dark and light map styles",
-      "zones": "Tap a zone to view its species list"
+      "species": "Wähle eine Art mit dem Selektor",
+      "locate": "Zentriere die Karte auf deinen Standort",
+      "numbers": "Zeige oder verberge den numerischen Index",
+      "theme": "Wechsle zwischen dunklem und hellem Kartenstil",
+      "zones": "Tippe auf eine Zone, um die Artenliste anzuzeigen"
     },
-    "instructions": "Read full instructions",
-    "dismiss": "Start exploring"
+    "instructions": "Vollständige Anleitung lesen",
+    "dismiss": "Erkunden starten"
   }
 }

--- a/src/i18n/locales/de/map.json
+++ b/src/i18n/locales/de/map.json
@@ -59,6 +59,7 @@
   "getLocation": "Meinen Standort ermitteln",
   "toggleNumbers": "Zahlen ein-/ausblenden",
   "toggleDarkMode": "Dunkelmodus umschalten",
+  "showOnboarding": "Show onboarding",
   "dataFreshnessTooltip": "Daten werden täglich aktualisiert",
   "featureInfo": {
     "title": "Feature-Details",

--- a/src/i18n/locales/en/map.json
+++ b/src/i18n/locales/en/map.json
@@ -58,6 +58,7 @@
   "getLocation": "Get My Location",
   "toggleNumbers": "Toggle Numbers",
   "toggleDarkMode": "Toggle Dark Mode",
+  "showOnboarding": "Show onboarding",
   "dataFreshnessTooltip": "Data refreshed daily",
   "featureInfo": {
     "title": "Feature Details",

--- a/src/i18n/locales/es/map.json
+++ b/src/i18n/locales/es/map.json
@@ -59,6 +59,7 @@
   "getLocation": "Obtener mi ubicación",
   "toggleNumbers": "Mostrar números",
   "toggleDarkMode": "Cambiar a modo oscuro",
+  "showOnboarding": "Show onboarding",
   "dataFreshnessTooltip": "Datos actualizados diariamente",
   "featureInfo": {
     "title": "Detalles de la función",

--- a/src/i18n/locales/es/map.json
+++ b/src/i18n/locales/es/map.json
@@ -59,7 +59,7 @@
   "getLocation": "Obtener mi ubicación",
   "toggleNumbers": "Mostrar números",
   "toggleDarkMode": "Cambiar a modo oscuro",
-  "showOnboarding": "Show onboarding",
+  "showOnboarding": "Mostrar instrucciones",
   "dataFreshnessTooltip": "Datos actualizados diariamente",
   "featureInfo": {
     "title": "Detalles de la función",
@@ -67,16 +67,16 @@
     "location": "Ubicación"
   },
   "onboarding": {
-    "title": "Explore wild species",
-    "description": "Use the map to discover foraging spots and species.",
+    "title": "Explora especies silvestres",
+    "description": "Usa el mapa para descubrir lugares de recolección y especies.",
     "features": {
-      "species": "Choose a species with the selector",
-      "locate": "Center the map on your location",
-      "numbers": "Show or hide the numeric index",
-      "theme": "Switch between dark and light map styles",
-      "zones": "Tap a zone to view its species list"
+      "species": "Elige una especie con el selector",
+      "locate": "Centra el mapa en tu ubicación",
+      "numbers": "Muestra u oculta el índice numérico",
+      "theme": "Cambia entre estilos de mapa claro y oscuro",
+      "zones": "Toca una zona para ver la lista de especies"
     },
-    "instructions": "Read full instructions",
-    "dismiss": "Start exploring"
+    "instructions": "Leer las instrucciones completas",
+    "dismiss": "Comenzar a explorar"
   }
 }

--- a/src/i18n/locales/fr/map.json
+++ b/src/i18n/locales/fr/map.json
@@ -59,6 +59,7 @@
   "getLocation": "Obtenir ma position",
   "toggleNumbers": "Afficher/masquer les notes",
   "toggleDarkMode": "Basculer en mode sombre",
+  "showOnboarding": "Show onboarding",
   "dataFreshnessTooltip": "Données mises à jour quotidiennement",
   "featureInfo": {
     "title": "Détails de la fonctionnalité",

--- a/src/i18n/locales/fr/map.json
+++ b/src/i18n/locales/fr/map.json
@@ -59,7 +59,7 @@
   "getLocation": "Obtenir ma position",
   "toggleNumbers": "Afficher/masquer les notes",
   "toggleDarkMode": "Basculer en mode sombre",
-  "showOnboarding": "Show onboarding",
+  "showOnboarding": "Afficher les instructions",
   "dataFreshnessTooltip": "Données mises à jour quotidiennement",
   "featureInfo": {
     "title": "Détails de la fonctionnalité",
@@ -67,16 +67,16 @@
     "location": "Emplacement"
   },
   "onboarding": {
-    "title": "Explore wild species",
-    "description": "Use the map to discover foraging spots and species.",
+    "title": "Explorer les espèces sauvages",
+    "description": "Utilisez la carte pour découvrir des lieux de cueillette et des espèces.",
     "features": {
-      "species": "Choose a species with the selector",
-      "locate": "Center the map on your location",
-      "numbers": "Show or hide the numeric index",
-      "theme": "Switch between dark and light map styles",
-      "zones": "Tap a zone to view its species list"
+      "species": "Choisissez une espèce avec le sélecteur",
+      "locate": "Centrer la carte sur votre position",
+      "numbers": "Afficher ou masquer l’index numérique",
+      "theme": "Basculer entre les styles de carte clair et sombre",
+      "zones": "Touchez une zone pour voir la liste des espèces"
     },
-    "instructions": "Read full instructions",
-    "dismiss": "Start exploring"
+    "instructions": "Lire les instructions complètes",
+    "dismiss": "Commencer l’exploration"
   }
 }

--- a/src/i18n/locales/it/map.json
+++ b/src/i18n/locales/it/map.json
@@ -58,6 +58,7 @@
   "getLocation": "Ottieni la Mia Posizione",
   "toggleNumbers": "Attiva/Disattiva Numeri",
   "toggleDarkMode": "Attiva/Disattiva Modalità Scura",
+  "showOnboarding": "Show onboarding",
   "dataFreshnessTooltip": "Dati aggiornati quotidianamente",
   "featureInfo": {
     "title": "Dettagli Feature",

--- a/src/i18n/locales/it/map.json
+++ b/src/i18n/locales/it/map.json
@@ -58,7 +58,7 @@
   "getLocation": "Ottieni la Mia Posizione",
   "toggleNumbers": "Attiva/Disattiva Numeri",
   "toggleDarkMode": "Attiva/Disattiva Modalità Scura",
-  "showOnboarding": "Show onboarding",
+  "showOnboarding": "Mostra istruzioni",
   "dataFreshnessTooltip": "Dati aggiornati quotidianamente",
   "featureInfo": {
     "title": "Dettagli Feature",
@@ -66,16 +66,16 @@
     "location": "Località"
   },
   "onboarding": {
-    "title": "Explore wild species",
-    "description": "Use the map to discover foraging spots and species.",
+    "title": "Esplora le specie selvatiche",
+    "description": "Usa la mappa per scoprire luoghi di raccolta e specie.",
     "features": {
-      "species": "Choose a species with the selector",
-      "locate": "Center the map on your location",
-      "numbers": "Show or hide the numeric index",
-      "theme": "Switch between dark and light map styles",
-      "zones": "Tap a zone to view its species list"
+      "species": "Scegli una specie con il selettore",
+      "locate": "Centra la mappa sulla tua posizione",
+      "numbers": "Mostra o nascondi l’indice numerico",
+      "theme": "Passa tra lo stile chiaro e scuro della mappa",
+      "zones": "Tocca una zona per vedere l’elenco delle specie"
     },
-    "instructions": "Read full instructions",
-    "dismiss": "Start exploring"
+    "instructions": "Leggi le istruzioni complete",
+    "dismiss": "Inizia a esplorare"
   }
 }

--- a/src/i18n/locales/pt/map.json
+++ b/src/i18n/locales/pt/map.json
@@ -59,6 +59,7 @@
   "getLocation": "Obter minha localização",
   "toggleNumbers": "Alternar números",
   "toggleDarkMode": "Alternar modo escuro",
+  "showOnboarding": "Show onboarding",
   "dataFreshnessTooltip": "Dados atualizados diariamente",
   "featureInfo": {
     "title": "Detalhes da funcionalidade",

--- a/src/i18n/locales/pt/map.json
+++ b/src/i18n/locales/pt/map.json
@@ -59,7 +59,7 @@
   "getLocation": "Obter minha localização",
   "toggleNumbers": "Alternar números",
   "toggleDarkMode": "Alternar modo escuro",
-  "showOnboarding": "Show onboarding",
+  "showOnboarding": "Mostrar instruções",
   "dataFreshnessTooltip": "Dados atualizados diariamente",
   "featureInfo": {
     "title": "Detalhes da funcionalidade",
@@ -67,16 +67,16 @@
     "location": "Localização"
   },
   "onboarding": {
-    "title": "Explore wild species",
-    "description": "Use the map to discover foraging spots and species.",
+    "title": "Explore espécies selvagens",
+    "description": "Use o mapa para descobrir locais de coleta e espécies.",
     "features": {
-      "species": "Choose a species with the selector",
-      "locate": "Center the map on your location",
-      "numbers": "Show or hide the numeric index",
-      "theme": "Switch between dark and light map styles",
-      "zones": "Tap a zone to view its species list"
+      "species": "Escolha uma espécie com o seletor",
+      "locate": "Centralize o mapa na sua localização",
+      "numbers": "Mostrar ou ocultar o índice numérico",
+      "theme": "Alternar entre estilos de mapa claro e escuro",
+      "zones": "Toque em uma zona para ver a lista de espécies"
     },
-    "instructions": "Read full instructions",
-    "dismiss": "Start exploring"
+    "instructions": "Ler instruções completas",
+    "dismiss": "Começar a explorar"
   }
 }


### PR DESCRIPTION
## Summary
- Add info button below dark mode toggle to reopen onboarding modal
- Allow onboarding modal to be triggered via UI store
- Add `showOnboarding` translation key

## Testing
- `npm run lint`
- `npm run test` *(fails: Missing Playwright browsers and Storybook exports)*

------
https://chatgpt.com/codex/tasks/task_e_68aad77d61a48331a37e6873c5992e29