### PR TITLE
Fix: Add a Sitemap for indexing via Google search #50

### DIFF
--- a/sitemap.xml
+++ b/sitemap.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset
+      xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"
+      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+      xsi:schemaLocation="http://www.sitemaps.org/schemas/sitemap/0.9
+            http://www.sitemaps.org/schemas/sitemap/0.9/sitemap.xsd">
+<!-- created with Free Online Sitemap Generator www.xml-sitemaps.com -->
+
+<url>
+  <loc>https://www.fung.es/</loc>
+  <lastmod>2025-09-27T20:01:03+00:00</lastmod>
+</url>
+<url>
+  <loc>https://www.fung.es/instructions</loc>
+  <lastmod>2025-09-27T20:01:03+00:00</lastmod>
+</url>
+<url>
+  <loc>https://www.fung.es/recipes</loc>
+  <lastmod>2025-09-27T20:01:03+00:00</lastmod>
+</url>
+<url>
+  <loc>https://www.fung.es/species</loc>
+  <lastmod>2025-09-27T20:01:03+00:00</lastmod>
+</url>
+<url>
+  <loc>https://www.fung.es/support</loc>
+  <lastmod>2025-09-27T20:01:03+00:00</lastmod>
+</url>
+<url>
+  <loc>https://www.fung.es/termsuse</loc>
+  <lastmod>2025-09-27T20:01:03+00:00</lastmod>
+</url>
+<url>
+  <loc>https://www.fung.es/privacy-policy</loc>
+  <lastmod>2025-09-27T20:01:03+00:00</lastmod>
+</url>
+
+</urlset>


### PR DESCRIPTION
## Description

Added a sitemap file to the project to enable proper indexing of the website via Google Search Console.

## Related Issue

Closes #50 (Bug: Add a Sitemap for indexing via Google search)

## Changes Made

- Added sitemap.xml to the project root.
- Configured the sitemap path to be accessible for search engine crawlers.

## Testing

Verified that the sitemap is accessible at https://fung.es/sitemap.xml.

## Checklist

- [x] My code follows the repository’s style guidelines  
- [x] I have performed a self-review of my code  
- [ ] I have added tests that prove my fix/feature works  
- [x] New and existing tests pass with my changes  
- [x] I have updated the documentation if necessary  

